### PR TITLE
fix: shell as package now prompts for device selection

### DIFF
--- a/scripts/adb_helper.sh
+++ b/scripts/adb_helper.sh
@@ -118,7 +118,7 @@ function _select_category {
 		if [ "$selected_operation" == "Exit" ]; then
 			exit 0
 		elif [ "$selected_operation" == "${operations[1]}" ]; then
-			_select_device_actions
+			select_device_actions
 		elif [ "$selected_operation" == "${operations[2]}" ]; then
 			_select_capture_action
 		elif [ "$selected_operation" == "${operations[3]}" ]; then

--- a/scripts/devices.sh
+++ b/scripts/devices.sh
@@ -3,10 +3,10 @@
 # This script contains functionality for direct device information retrieval
 # and interaction.
 #
-# It's entry point is _select_device_actions()
+# It's entry point is select_device_actions()
 # -----------------------------------------------------------------------------
 
-_select_device_actions () {
+select_device_actions () {
 	local operations
 	operations=("Cancel" "List devices" "Name sources" "Source lock" "List Android version" "Battery status" "Open shell" "Control")
 
@@ -35,6 +35,27 @@ _select_device_actions () {
 			continue
 		fi
 	done
+}
+
+select_serial_number () {
+	if [[ $# -lt 1 ]]; then
+		_error "${BASH_SOURCE[0]}, lineno: $LINENO: Expects one input parameter to function!"
+		return 1
+	fi
+
+	local result_code outvar
+	outvar="$1"
+
+	selected="-s"
+	serial_number=$(_get_serial_numbers "select trigger")
+	result_code=$?
+
+	if [  $result_code -ne 0 ]; then
+		return "$result_code"
+	fi
+
+	results=("$selected" "$serial_number")
+	printf -v "$outvar" "%s " "${results[@]}"
 }
 
 _get_device_android_version () {

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -353,12 +353,37 @@ _shell_as_package () {
 		exit 1
 	fi
 
-	local package
+	local result result_code result_array package local_source_flag local_serial_number
 	package="$1"
+
+	if [ "$ADBH_SOURCE_FLAG" != "-s" ]; then
+		_warning "This operation requires that a specific device be selected for use ('-d' flag will not work)!"
+		read -n 1 -s -r -p "Press any key to continue..."
+
+		select_serial_number result
+		result_code="$?"
+		IFS=' ' read -ra result_array <<< "$result"
+
+		if [  $result_code -eq "$CODE_CANCEL" ]; then
+			return "$CODE_CANCEL"
+		elif [ $result_code -ne 0 ]; then
+			error "${BASH_SOURCE[0]}, lineno: $LINENO: ${result_array[0]}"
+			return $result_code
+		fi
+
+		local_source_flag="${result_array[0]}"
+		local_serial_number="${result_array[1]}"
+	else
+		local_source_flag="${ADBH_SOURCE_FLAG}"
+		local_serial_number="${ADBH_SERIAL_NUMBER}"
+	fi
 
 	_warning "Requires package to be in debug mode!"
 
-	./adb_shell_expect.sh "${ADBH_SOURCE_FLAG}" "${ADBH_SERIAL_NUMBER}" "run-as $package"
+	local SCRIPT_DIR=
+	SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+	"${SCRIPT_DIR}/adb_shell_expect.sh" "${local_source_flag}" "${local_serial_number}" "run-as ${package}"
 }
 
 _force_stop_package () {


### PR DESCRIPTION
The action of shelling into a device as a specific package requires that a specific device be also selected. This fix adds checks and a prompt for selection of a device serial code if missing.